### PR TITLE
Feature request #38: Case insensitive comparison between invitation email and user email

### DIFF
--- a/enrol.php
+++ b/enrol.php
@@ -74,12 +74,12 @@ if ($reject) {
     $invitation->errormsg = '';
     if (isloggedin() && !isguestuser()) { // Logged-in.
         // Ensure that this is the expected user.
-        if ((empty($invitation->userid) && $invitation->email == $USER->email)
+        if ((empty($invitation->userid) && strtolower($invitation->email) == strtolower($USER->email))
                 || (!empty($invitation->userid) && $invitation->userid == $USER->id)) {
             // Allow rejection if either the user did not have an account at the time of invitation (userid=null) but email
             // addresses match, OR if the user's ID matches the one in the invitation. Prevent users from swapping email addresses.
             $userid = $USER->id;
-        } else if (empty($userid) && $invitation->email != $USER->email) {
+        } else if (empty($userid) && strtolower($invitation->email) != strtolower($USER->email)) {
             // User had no account at the time of invitation which is fine but mail addresses do not match.
             $invitation->errormsg = 'email does not match';
         } else { // If the userid does not match the current USER id, invitation was sent to a user with a different userid.
@@ -153,7 +153,7 @@ require_login(null, false);
 // We allow invitation acceptance by logged-in users only. Acceptance request will be rejected if a userid is set and they don't
 // match or if the email address does not match. If a user created account since invitation, the userid will not match but email
 // address should. This will also ensure that 2 user accounts did not swap email addresses.
-if ((empty($invitation->userid) && $invitation->email == $USER->email) || $invitation->userid == $USER->id) {
+if ((empty($invitation->userid) && strtolower($invitation->email) == strtolower($USER->email)) || $invitation->userid == $USER->id) {
     $userid = $USER->id;
 } else {
     // This is not the expected user. Log and display access denied message.


### PR DESCRIPTION
Hi Michael,

Is it possible to make the comparison between the invitation email and user email case insensitive? Currently, if a teacher doesn't notice capitals in an email address or receives the addresses without capitals from a different system, it results in students getting the message of 'Invitation intended for a different user'.

I've made a few small adjustments and tested it on our Moodle instances. Hope that you want to incorporate this in the plugin. 

Thanks,
Matty from Utrecht University