### PR TITLE
Use random_bytes() instead of uniqid() to generate invitation tokens

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -124,7 +124,7 @@ class invitation_manager {
                 } else {
                     // Create unique token for invitation.
                     do {
-                        $token = uniqid();
+                        $token = bin2hex(random_bytes(16));
                         $existingtoken = $DB->get_record('enrol_invitation', ['token' => $token]);
                     } while (!empty($existingtoken));
                 }


### PR DESCRIPTION
Use the random_bytes() method to generate cryptographically secure 128-bit invitation tokens.

Note that this increases the token length from 13 to 32 characters. The length could be reduced by using URL-safe base64 encoding instead of hex encoding, but this would make the URL case-sensitive and might break backwards compatibility in environments which rely on the token being all lowercase.

**Example**
Old: https://example.com/enrol/invitation/enrol.php?token=6851613b471df
New: https://example.com/enrol/invitation/enrol.php?token=448ba5cb3f79e1f66f38202be7950091

Fixes #51.