### PR TITLE
Fix call to moodle_exception contructor.

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -458,7 +458,7 @@ class invitation_manager {
             $user = $USER;
         } else {
             $noticeobject = preparenoticeobject($invitation);
-            throw new moodle_exception('loggedinnot', 'enrol_invitation', $noticeobject);
+            throw new moodle_exception('loggedinnot', 'enrol_invitation', '', $noticeobject);
         }
 
         $enrol = enrol_get_plugin('invitation');


### PR DESCRIPTION
In moodle_exception constructor, the 3rd parameter is a string (link URL), while the lang string parameter is 4th: https://github.com/moodle/moodle/blob/213a869e7ffd48d3a5679818bcddbb22dbc31aa5/public/lib/classes/exception/moodle_exception.php#L59